### PR TITLE
バグの修正と改善

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -3,7 +3,7 @@
 class TasksController < ApplicationController
   def index
     # @tasks = Task.all
-    @tasks = current_user.tasks # Userオブジェクトに紐づくタスクオブジェクト一覧を取得
+    @tasks = current_user.tasks.order(created_at: :desc) # Userオブジェクトに紐づくタスクオブジェクト一覧を取得
   end
 
   def show
@@ -23,7 +23,7 @@ class TasksController < ApplicationController
     # @task = Task.new(task_params.merge(user_id: current_user.id)) # Create a Task object by retrieving the secured value in task_params
     @task = current_user.tasks.new(task_params) # Userオブジェクトに紐づくタスクオブジェクトを生成
     if @task.save # Once the task instance is saved,
-      redirect_to tasks, notice: "タスク「#{@task.name}」を登録しました。"
+      redirect_to tasks_url, notice: "タスク「#{@task.name}」を登録しました。"
     # if it's not the page you were on when you registered, you can redirect to the specified URL
     # If nothing is specified, render will return to the original page (new)
     else

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -3,7 +3,7 @@ class Task < ApplicationRecord
   validates :name, presence: true, length: { maximum: 30 }
   validate :validate_name_not_including_comma
 
-  belongs_to :User
+  belongs_to :user
   # このクラスは belongs_to で指定したクラスに従属している
   # 従属先のクラスのidを利用したレコードを複数登録可能
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   has_secure_password
 
   validates :name, presence: true
-  validates :email, presence: true, uniqueness: true
+  validates :email, presence: true
 
   has_many :tasks
   # このクラスのidを外部キーとして渡し、manyで渡された側で外部キーが複数登録可能

--- a/app/views/admin/users/new.html.slim
+++ b/app/views/admin/users/new.html.slim
@@ -4,22 +4,3 @@ h1 ユーザー登録
   = link_to  "一覧", admin_users_path, class: 'nav-link'
 
 = render  partial: 'form', locals: { user: @user }
-
-= form_with model: [:admin, @user], local: true do |f|
-  .form-group
-    = f.label :name, '名前'
-    = f.text_field :name, class: 'form-control'
-  .form-group
-    = f.label :email, 'メールアドレス'
-    = f.text_field :email, class: 'form-control'
-  / .form-check
-  /   = f.label :admin, class: 'form-check-label' do
-  /     = f.check_box :admin, class: 'form-check-input'
-  /     | 管理者権限
-  / .form-group
-  /   = f.label :password, 'パスワード'
-  /   = f.password_field :password, class: 'form-control'
-  / .form-group
-  /   = f.label :password_confirmation, 'パスワード(確認)'
-  /   = f.password_field :password_confirmation, class: 'form-control'
-  / = f.submit '登録する', class: 'btn btn-primary'

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -15,6 +15,7 @@ html
 
       ul.navbar-nav.ml-auto
         - if current_user
+          li.nav-item= link_to  "ユーザ名:#{current_user.name}", tasks_path, class: 'nav-link text-white'
           li.nav-item= link_to  "タスク一覧", tasks_path, class: 'nav-link text-white'
           - if current_user.admin? # current_userがadmin権限(管理者ユーザ)であるか
             li.nav-item= link_to  "ユーザ一覧", admin_users_path, class: 'nav-link text-white'

--- a/app/views/tasks/new.html.slim
+++ b/app/views/tasks/new.html.slim
@@ -4,4 +4,4 @@ h1 タスクの新規登録
 .nav.justify-content-end
   = link_to '一覧', tasks_path, class: 'nav-link'
 
-= render partial: 'form',locals: { task: @task }
+= render partial: 'form', locals: { task: @task }


### PR DESCRIPTION
- スペルミスを修正により、ユーザごとの投稿を実現
- パーシャルにより、新規ユーザ登録フォームが重複して表示されていたので、無駄なコードを除去
- 投稿一覧を最新順にする
- ヘッダーにログイン中のユーザ名を表示する
